### PR TITLE
build: adding support to rewrite URL to make it easier

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,10 @@
   publish = "."
 [functions]
   node_bundler = "esbuild"
+[[redirects]]
+  from = '/api/*'
+  to = '/.netlify/functions/:splat'
+  status = 200
 
   ## Uncomment to use this redirect for Single Page Applications like create-react-app.
   ## Not needed for static site generators.


### PR DESCRIPTION
Instead of using the long url, we can overwrite to make it easier. This will allow you to do `host/api/anime`